### PR TITLE
fix: update `app.css` path in `welcome.blade.php`

### DIFF
--- a/templates/default/resources/views/welcome.blade.php
+++ b/templates/default/resources/views/welcome.blade.php
@@ -11,7 +11,7 @@
         <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
 
         <!-- Styles -->
-        <link rel="stylesheet" href="{{ mix('build/app.css') }}" />
+        <link rel="stylesheet" href="{{ mix('css/app.css') }}" />
     </head>
     <body class="antialiased">
         <div class="relative flex justify-center min-h-screen pb-4 bg-gray-100 items-top dark:bg-gray-900 sm:items-center sm:pt-0">


### PR DESCRIPTION
If you make a new plain project and apply the preset, you'll get this message:

```Unable to locate Mix file: /build/app.css.```

That is because by default Laravel ships `app.css` into the `css` folder:
https://github.com/laravel/laravel/blob/588247b790f4f0d13296247f8140b1466e1e6936/webpack.mix.js#L15

